### PR TITLE
feat:deleting endpoint now works this seems to be end of book api

### DIFF
--- a/src/controllers/bookController.js
+++ b/src/controllers/bookController.js
@@ -37,4 +37,44 @@ const updateBook = async (req, res, next) => {
     next(err);
   }
 };
-export { getBooks, createBook, updateBook };
+const deleteBook = async (req,res,next)=>{
+  try{
+  const {id} = req.params;
+  const deletedBook = await service.deleteBookById(id);
+
+  res.status(204).json({
+    success:true,
+    data:deletedBook,
+
+  });
+  if(!deletedBook){
+    res.status(404).json({
+      success:false,
+      message:"Book Not Found"
+    })
+  }
+}
+catch(err){
+  next(err)
+}
+};
+const getBookById = async(req,res,next)=>{
+  try{
+  const id = req.params?.id;
+   if (!id) {
+    return res.status(400).json({
+      success: false,
+      message: "ID is required",
+    });
+  }
+  const result = await service.getBook(id);
+  if(!result.success){
+    return res.status(404).json(result)
+  }
+  res.status(200).json(result);}
+  catch(err){
+    next(err);
+  }
+
+}
+export { getBooks, createBook, updateBook,deleteBook,getBookById };

--- a/src/repositories/bookRepository.js
+++ b/src/repositories/bookRepository.js
@@ -16,4 +16,11 @@ const update = async (id, updateBook) => {
   
   return books[index];
 };
-export { getAll, createBook, update,findById };
+const remove = async (id)=>{
+  const index = books.findIndex(b => b.id === id);
+  if(index < 0) return null;
+  const deletedBook = books.splice(index,1);
+  return deletedBook[0];
+}
+
+export { getAll, createBook ,update,findById,remove};

--- a/src/routes/bookRoutes.js
+++ b/src/routes/bookRoutes.js
@@ -7,8 +7,10 @@ import  updateBookMiddlewares from "../middleware/validateBookUpdate.js";
 const router = express.Router();
 
 router.get("/", controller.getBooks);
+router.get("/:id", controller.getBookById);
 router.post("/", validateBody(createBookSchema), controller.createBook);
 router.put("/:id", updateBookMiddlewares, controller.updateBook);
+router.delete("/:id", controller.deleteBook)
 
 
 export default router;

--- a/src/services/bookService.js
+++ b/src/services/bookService.js
@@ -43,5 +43,27 @@ const book = repository.findById(id);
   };
   return await repository.update(id, updatedBook);
 };
+const deleteBookById = async (id)=>{
+  let book = await repository.remove(id);
+  if(!book){
+    throw new appError("Book Not Found",404);
+  }
+  return book;
+ 
+}
+//get by id 
+const getBook = async (id)=>{
+  const book = await repository.findById(id);
+  if(!book){
+    return {
+      success:false,
+      message: "Book Not Found"
+    }
+  }
+  return {
+    success:true,
+    data:book
+  };
+}
 
-export { getAllBooks, createBook, updateBook };
+export { getAllBooks,createBook,updateBook,deleteBookById,getBook };


### PR DESCRIPTION
# What PR does.
- Add feature to get one book by calling it's id, So that librarian can call specific book by just calling id 
- This is last update all features for book end by this get by id 
- All feature includes DELETE, UPDATE, GET all,GET by id, CREATE works well.
## How to test it
- run:
```
npm run dev
```
## What expected when ran success (200 OK)
> GET:
```
localhost:4000/api/books/a1b2c3
```
> BODY:
```
  "success": true,
    "data": {
        "id": "fb904cdd-30d0-492d-b8d0-8a1418a445d4",
        "title": "The Pragmatic Programmer",
        "author": "Nahimana Janvier",
        "isbn": 9780135957059,
        "genre": "Information  Technology",
        "totalCopies": 2,
        "availableCopies": 2,
        "createdAt": "2026-04-18T09:47:06.058Z"
    }
}
```
## What expected when called invalid id (404 Not Found)
> GET:
```
localhost:4000/api/books/a1b2c3khjgjhg
```
```
{
    "success": false,
    "message": "Book Not Found"
}
```