### PR TITLE
feat:add PATCH api/loans/:id/return/ records that borrowed book has been returned

### DIFF
--- a/src/controllers/loanController.js
+++ b/src/controllers/loanController.js
@@ -18,4 +18,21 @@ const createLoans = async (req, res, next) => {
    })
   }}
 };
-export default createLoans;
+const returnBook = async (req,res,next)=>{
+    try{
+    const {id} = req.params;
+    const loan = await loanService.returnBook(id);
+
+    return res.status(200).json({
+        success:true,
+        data:loan
+    })
+}catch(err){
+   if(err instanceof appError){
+   return res.status(err.statusCode).json({
+    success:false,
+    message:err.message
+   })
+  }}
+}
+export{createLoans, returnBook} ;

--- a/src/repositories/loanRepository.js
+++ b/src/repositories/loanRepository.js
@@ -5,5 +5,9 @@ const createLoan = async (newLoan)=>{
    loans.push(newLoan);
    return newLoan;
 }
+const findById = (id)=>{
+  const loan = loans.find(loan =>loan.id === id);
+  return loan;
+}
 
-export { createLoan };
+export { createLoan,findById };

--- a/src/routes/loanRoutes.js
+++ b/src/routes/loanRoutes.js
@@ -1,8 +1,9 @@
 import express from 'express';
-import createLoans from '../controllers/loanController.js';
+import * as loanController from '../controllers/loanController.js';
 
 const router = express.Router();
 
-router.post('/', createLoans);
+router.post('/', loanController.createLoans);
+router.patch('/:id/return', loanController.returnBook);
 
 export default router;

--- a/src/services/loanService.js
+++ b/src/services/loanService.js
@@ -34,5 +34,27 @@ const createLoan = async (loan) => {
 
   return await loanRepository.createLoan(newLoan);
 };
+const returnBook = async (id) => {
 
-export { createLoan };
+  const loan = await loanRepository.findById(id);
+
+  if (!loan) {
+    throw new appError("Loan not found", 404);
+  }
+  const book = await bookRepository.findById(loan.bookId);
+
+
+  if (loan.returnedAt === null) {
+    loan.returnedAt = new Date().toISOString();
+
+     book.availableCopies++;
+     bookRepository.update(book);
+    return loan;
+  } else {
+    throw new appError("This loan has already been returned", 409);
+  }
+  
+  return loan;
+};
+
+export { createLoan, returnBook };


### PR DESCRIPTION
# What PR does 
- Records when user returned borrowed book, and increment number of availableCopies by 1
- set returnedAt to current date and time.
- tell borrower whether book is already returned

## Expected when book returned (200 Ok)
- BODY:
```
{
  "success": true, 
  "data": {
    "id": "l1m2n3",  // id is generated by uuid()
    "bookId": "a1b2c3",
    "userId": "u7h8i9",
    "borrowedAt": "2024-01-16T11:00:00.000Z",
    "dueDate": "2024-02-16T00:00:00.000Z",
    "returnedAt": "2024-01-20T14:30:00.000Z"
  }
}
```

>  after book returned successfully system update number of `availableCopies` by 1
## Expected when book is already returned(409 Conflict) or loan does not exist(404 Not found)
> if return book that isn't exist in loan
- BODY:
```
{
  "success": false,
  "message": "Loan not found"
}
```
> if loan has been already returned
- BODY:
```
{
  "success": false,
  "message": "This loan has already been returned"
}
```






